### PR TITLE
Fix piece snapping when moved within original square

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -409,6 +409,9 @@ const handleMouseUp = async (event) => {
         notation: toChessNotation(newRow, newCol) 
       });
       
+      // Return the piece to the center of its square
+      returnPiece(movingPiece);
+      
       // Reset the dragging state without further processing
       draggingPiece.value = null;
       validMoves.value = [];


### PR DESCRIPTION
When a piece was moved within its own square and released, it would stay where it was dropped rather than snapping back to the center of the square. This fix ensures a consistent snapping behavior by calling returnPiece for within-square drops.

🤖 Generated with [Claude Code](https://claude.ai/code)